### PR TITLE
feat(testnets): dingo variants

### DIFF
--- a/compose/Dockerfile.dingo
+++ b/compose/Dockerfile.dingo
@@ -1,6 +1,6 @@
 ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.8.0.0}"
 ARG CARDANO_NODE_VERSION="${CARDANO_NODE_VERSION:-10.4.1}"
-ARG DINGO_VERSION="${DINGO_VERSION:-0.13.0}"
+ARG DINGO_VERSION="${DINGO_VERSION:-latest}"
 ARG UV_VERSION="${UV_VERSION:-0.6.11}"
 # Blink Labs images are built from source on Debian Bookworm
 FROM ghcr.io/blinklabs-io/cardano-cli:${CARDANO_CLI_VERSION} AS cardano-cli

--- a/compose/configurator/configurator.sh
+++ b/compose/configurator/configurator.sh
@@ -128,6 +128,9 @@ set_start_time() {
 
     # .startTime
     jq ".startTime = ${SYSTEM_START_UNIX}" "${BYRON_GENESIS_JSON}" | write_file "${BYRON_GENESIS_JSON}"
+
+    # .ftsSeed (Dingo as of 0.17 needs this as a string, empty so removing it)
+    jq "del(.ftsSeed)" "${BYRON_GENESIS_JSON}" | write_file "${BYRON_GENESIS_JSON}"
 }
 
 

--- a/compose/testnets/cardano_node_10.4.1_dingo/README.md
+++ b/compose/testnets/cardano_node_10.4.1_dingo/README.md
@@ -1,6 +1,6 @@
 # Description
 
-A 5 pools testnet using cardano-node version 10.4.1 testing consistency between nodes runnning UTxO-HD with LMDB and in-memory: We run 3 nodes with in-memory DB and 2 node with LMDB and check they are still consistent. A single Dingo 0.13.0 node is added to the network as a client not producing blocks.
+A 5 pools testnet using cardano-node version 10.4.1 testing consistency between nodes runnning UTxO-HD with LMDB and in-memory: We run 3 nodes with in-memory DB and 2 node with LMDB and check they are still consistent. A single Dingo node is added to the network as a client not producing blocks.
 
 ## Cardano-Node
 
@@ -10,7 +10,7 @@ A 5 pools testnet using cardano-node version 10.4.1 testing consistency between 
 
 ## Dingo
 
-- **Version**: 0.13.0
+- **Version**: latest
 - **Branch**: -
 - **Source/Compiled**: Compiled
 

--- a/compose/testnets/cardano_node_10.5.1_dingo/README.md
+++ b/compose/testnets/cardano_node_10.5.1_dingo/README.md
@@ -1,0 +1,19 @@
+# Description
+
+A 5 pools testnet using cardano-node version 10.5.1 testing consistency between nodes runnning UTxO-HD with LMDB and in-memory: We run 3 nodes with in-memory DB and 2 node with LMDB and check they are still consistent. A single Dingo node is added to the network as a client not producing blocks.
+
+## Cardano-Node
+
+- **Version**: 10.5.1
+- **Branch**: -
+- **Source/Compiled**: Compiled
+
+## Dingo
+
+- **Version**: latest
+- **Branch**: -
+- **Source/Compiled**: Compiled
+
+## Testnet
+
+- **Pools**: 5

--- a/compose/testnets/cardano_node_10.5.1_dingo/docker-compose.yaml
+++ b/compose/testnets/cardano_node_10.5.1_dingo/docker-compose.yaml
@@ -7,7 +7,7 @@ x-base: &base
     context: "../../"
     dockerfile: "Dockerfile.compiled"
     args:
-      CARDANO_NODE_VERSION: "10.4.1"
+      CARDANO_NODE_VERSION: "10.5.1"
 
 x-tracer-base: &tracerbase
   image: ${registry}${testnet}_tracer:latest
@@ -19,7 +19,7 @@ x-tracer-base: &tracerbase
     # https://github.com/IntersectMBO/cardano-node/issues/6228
     dockerfile: "Dockerfile.compiled"
     args:
-      CARDANO_NODE_REF: "10.4.1"
+      CARDANO_NODE_REF: "10.5.1"
 
 x-env: &env
   POOL_ID: "0" # Placeholder required for override

--- a/compose/testnets/cardano_node_10.5.1_dingo/testnet.yaml
+++ b/compose/testnets/cardano_node_10.5.1_dingo/testnet.yaml
@@ -1,0 +1,134 @@
+--- # Required Testnet Parameters
+poolCount: 5
+poolCost: 340000000
+poolMargin: 0.0
+poolPledge: 0
+delegatedSupply: 600000000000000
+systemStart: 'now'
+systemStartDelay: 5
+networkMagic: 42
+testnetDomain: example
+
+--- # Optional Byron Genesis Overide
+protocolConsts:
+  k: 432
+
+--- # Optional Shelley Genesis Overide
+epochLength: 86400
+securityParam: 432
+maxLovelaceSupply: 45000000000000000
+protocolParams:
+  decentralisationParam: 0
+  protocolVersion:
+    major: 10
+    minor: 0
+
+--- # Optional Alonzo Genesis Overide
+
+--- # Optional Conway Genesis Overide
+
+--- # Optional Node Config Overide
+ExperimentalHardForksEnabled: true
+ExperimentalProtocolsEnabled: true
+LastKnownBlockVersion-Alt: 0
+LastKnownBlockVersion-Major: 6
+LastKnownBlockVersion-Minor: 0
+MaxConcurrencyBulkSync: 2
+MaxConcurrencyDeadline: 4
+MaxKnownMajorProtocolVersion: 2
+PeerSharing: true
+TargetNumberOfActiveBigLedgerPeers: 2
+TargetNumberOfActivePeers: 3
+TargetNumberOfEstablishedBigLedgerPeers: 3
+TargetNumberOfEstablishedPeers: 3
+TargetNumberOfKnownBigLedgerPeers: 10
+TargetNumberOfKnownPeers: 30
+TargetNumberOfRootPeers: 10
+TestAllegraHardForkAtEpoch: 0
+TestAlonzoHardForkAtEpoch: 0
+TestBabbageHardForkAtEpoch: 0
+TestConwayHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
+TestShelleyHardForkAtEpoch: 0
+TraceConnectionManager: true
+TraceConnectionManagerTransitions: true
+TraceDNSResolver: true
+TraceDNSSubscription: true
+TraceDebugPeerSelection: true
+TraceForge: true
+TraceForgeStateInfo: true
+TraceHandshake: true
+TraceInboundGovernor: true
+TraceIpSubscription: true
+TraceLedgerPeers: true
+TraceLocalConnectionManager: true
+TraceLocalHandshake: true
+TraceLocalRootPeers: true
+TracePeerSelection: true
+TracePeerSelectionActions: true
+TracePublicRootPeers: true
+TraceServer: true
+TurnOnLoggingMetrics: true
+TurnOnLogging: true
+UseTraceDispatcher: true
+TraceOptionForwarder:
+  connQueueSize: 64
+  disconnQueueSize: 128
+  maxReconnectDeplay: 30
+TraceOptions:
+  '':
+    backends:
+    - EKGBackend
+    - Forwarder
+    detail: DNormal
+    severity: Notice
+  BlockFetch.Client.CompletedBlockFetch:
+    maxFrequency: 2
+  BlockFetch.Decision:
+    severity: Silence
+  ChainDB:
+    severity: Info
+  ChainDB.AddBlockEvent.AddBlockValidation:
+    severity: Silence
+  ChainDB.AddBlockEvent.AddBlockValidation.ValidCandidate:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToQueue:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToVolatileDB:
+    maxFrequency: 2
+  ChainDB.CopyToImmutableDBEvent.CopiedBlockToImmutableDB:
+    maxFrequency: 2
+  ChainSync.Client:
+    severity: Warning
+  Forge.Loop:
+    severity: Info
+  Forge.StateInfo:
+    severity: Info
+  Mempool:
+    severity: Silence
+  Net.ConnectionManager.Remote:
+    severity: Info
+  Net.ConnectionManager.Remote.ConnectionManagerCounters:
+    severity: Silence
+  Net.ErrorPolicy:
+    severity: Info
+  Net.ErrorPolicy.Local:
+    severity: Info
+  Net.InboundGovernor:
+    severity: Warning
+  Net.InboundGovernor.Remote:
+    severity: Info
+  Net.Mux.Remote:
+    severity: Info
+  Net.PeerSelection:
+    severity: Silence
+  Net.PeerSelection.Actions:
+    severity: Info
+  Net.Subscription.DNS:
+    severity: Info
+  Net.Subscription.IP:
+    severity: Info
+  Resources:
+    severity: Silence
+  Startup.DiffusionInit:
+    severity: Info

--- a/compose/testnets/cardano_node_with_adversary_and_dingo/README.md
+++ b/compose/testnets/cardano_node_with_adversary_and_dingo/README.md
@@ -1,0 +1,19 @@
+# Description
+
+A 5 pools testnet using cardano-node version 10.5.1 testing consistency between nodes runnning UTxO-HD with LMDB and in-memory: We run 3 nodes with in-memory DB and 2 node with LMDB and check they are still consistent. A single Dingo node is added to the network as a client not producing blocks.
+
+## Cardano-Node
+
+- **Version**: 10.5.1
+- **Branch**: -
+- **Source/Compiled**: Compiled
+
+## Dingo
+
+- **Version**: latest
+- **Branch**: -
+- **Source/Compiled**: Compiled
+
+## Testnet
+
+- **Pools**: 5

--- a/compose/testnets/cardano_node_with_adversary_and_dingo/dingo-topology.json
+++ b/compose/testnets/cardano_node_with_adversary_and_dingo/dingo-topology.json
@@ -1,0 +1,18 @@
+{
+  "localRoots": [
+    {
+      "accessPoints": [
+        {"address": "p1.example", "port": 3001},
+        {"address": "p2.example", "port": 3001},
+        {"address": "p3.example", "port": 3001},
+        {"address": "p4.example", "port": 3001},
+        {"address": "p5.example", "port": 3001}
+      ],
+    "advertise": true,
+    "trustable": true,
+    "valency": 2
+    }
+  ],
+    "publicRoots": [],
+    "useLedgerAfterSlot": 0
+}

--- a/compose/testnets/cardano_node_with_adversary_and_dingo/docker-compose.yaml
+++ b/compose/testnets/cardano_node_with_adversary_and_dingo/docker-compose.yaml
@@ -1,0 +1,156 @@
+x-cardano-node: &cardano-node
+  image: ghcr.io/blinklabs-io/cardano-node:latest
+  environment:
+    CARDANO_BLOCK_PRODUCER: true
+    RESTORE_SNAPSHOT: false
+  command: >
+    run --topology /configs/configs/topology.json
+      --config /configs/configs/config.json
+      --database-path /state
+      --socket-path /state/node.socket
+      --tracer-socket-path-connect /tracer/tracer.socket
+      --shelley-operational-certificate /configs/keys/opcert.cert
+      --shelley-kes-key /configs/keys/kes.skey
+      --shelley-vrf-key /configs/keys/vrf.skey
+      --port 3001
+      --host-addr 0.0.0.0
+      +RTS -N -A16m -qg -qb -RTS
+  restart:
+    always
+  depends_on:
+      configurator:
+        condition: service_completed_successfully
+
+services:
+  configurator:
+    image: ghcr.io/cardano-foundation/antithesis/configurator:latest
+    container_name: configurator
+    volumes:
+      - ./testnet.yaml:/testnet.yaml #  source of configurations
+      - p1-configs:/configs/1 # configs for p1
+      - p2-configs:/configs/2 # configs for p2
+      - p3-configs:/configs/3 # configs for p3
+      - p4-configs:/configs/4 # configs for p4
+      - p5-configs:/configs/5 # configs for p5
+
+  tracer:
+    image: ghcr.io/cardano-foundation/antithesis/tracer:latest
+    hostname: tracer.example
+    container_name: tracer
+    volumes:
+      - tracer:/opt/cardano-tracer
+    command:
+       - "--config"
+       - "tracer-config.yaml"
+
+  d1:
+    image: ghcr.io/blinklabs-io/dingo:latest
+    restart: on-failure
+    hostname: d1.example
+    container_name: d1
+    volumes:
+      - p1-configs:/configs # reuse p1 config
+      - tracer:/tracer
+      - ./dingo-topology.json:/opt/cardano/config/devnet/topology.json
+    environment:
+      CARDANO_CONFIG: /configs/configs/config.json
+      CARDANO_DATABASE_PATH: /state
+      CARDANO_NETWORK: devnet
+      CARDANO_NODE_SOCKET_PATH: /state/dingo.socket
+      CARDANO_SOCKET_PATH: /state/dingo.socket
+      CARDANO_TOPOLOGY: /opt/cardano/config/devnet/topology.json
+    depends_on:
+      configurator:
+        condition: service_completed_successfully
+
+  p1:
+    <<: *cardano-node
+    container_name: p1
+    hostname: p1.example
+    ports:
+      - 3001:3001
+    volumes:
+      - p1-configs:/configs
+      - tracer:/tracer
+
+  p2:
+    <<: *cardano-node
+    container_name: p2
+    hostname: p2.example
+    volumes:
+      - p2-configs:/configs
+      - tracer:/tracer
+
+  p3:
+    <<: *cardano-node
+    container_name: p3
+    hostname: p3.example
+    volumes:
+      - p3-configs:/configs
+      - tracer:/tracer
+
+  p4:
+    <<: *cardano-node
+    container_name: p4
+    hostname: p4.example
+    volumes:
+      - p4-configs:/configs
+      - tracer:/tracer
+
+  p5:
+    <<: *cardano-node
+    container_name: p5
+    hostname: p5.example
+    volumes:
+      - p5-configs:/configs
+      - tracer:/tracer
+
+  sidecar:
+    image: ghcr.io/cardano-foundation/antithesis/sidecar:latest
+    container_name: sidecar
+    hostname: sidecar.example
+    environment:
+      POOLS: "5" # FIXME: could remove
+      EXTRA_NODES: "d1"
+
+  tracer-sidecar:
+    image: ghcr.io/cardano-foundation/antithesis/tracer-sidecar:latest
+    container_name: tracer-sidecar
+    hostname: tracer-sidecar.example
+    environment:
+      POOLS: "5"
+      CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
+    volumes:
+      - tracer:/opt/cardano-tracer
+
+  adversary:
+    image: ghcr.io/cardano-foundation/antithesis/adversary:latest
+    build:
+      context: "../../../adversary/"
+      dockerfile: "Dockerfile"
+      args:
+        CARDANO_NODE_REF: "10.5.1"
+    environment:
+      NETWORKMAGIC: 42
+      PORT: 3001
+      LIMIT: 100
+      POOLS: "5"
+      CHAINPOINT_FILEPATH: "/opt/cardano-tracer/chainPoints.log"
+    hostname: adversary
+    container_name: adversary
+    volumes:
+      - tracer:/opt/cardano-tracer
+
+volumes:
+  tracer:
+  p1-configs:
+  p2-configs:
+  p3-configs:
+  p4-configs:
+  p5-configs:
+
+networks:
+  default:
+    name: cardano-node-testnet
+    driver: bridge
+    internal: ${INTERNAL_NETWORK}

--- a/compose/testnets/cardano_node_with_adversary_and_dingo/testnet.yaml
+++ b/compose/testnets/cardano_node_with_adversary_and_dingo/testnet.yaml
@@ -1,0 +1,134 @@
+--- # Required Testnet Parameters
+poolCount: 5
+poolCost: 340000000
+poolMargin: 0.0
+poolPledge: 0
+delegatedSupply: 600000000000000
+systemStart: 'now'
+systemStartDelay: 5
+networkMagic: 42
+testnetDomain: example
+
+--- # Optional Byron Genesis Overide
+protocolConsts:
+  k: 432
+
+--- # Optional Shelley Genesis Overide
+epochLength: 86400
+securityParam: 432
+maxLovelaceSupply: 45000000000000000
+protocolParams:
+  decentralisationParam: 0
+  protocolVersion:
+    major: 10
+    minor: 0
+
+--- # Optional Alonzo Genesis Overide
+
+--- # Optional Conway Genesis Overide
+
+--- # Optional Node Config Overide
+ExperimentalHardForksEnabled: true
+ExperimentalProtocolsEnabled: true
+LastKnownBlockVersion-Alt: 0
+LastKnownBlockVersion-Major: 6
+LastKnownBlockVersion-Minor: 0
+MaxConcurrencyBulkSync: 2
+MaxConcurrencyDeadline: 4
+MaxKnownMajorProtocolVersion: 2
+PeerSharing: true
+TargetNumberOfActiveBigLedgerPeers: 2
+TargetNumberOfActivePeers: 3
+TargetNumberOfEstablishedBigLedgerPeers: 3
+TargetNumberOfEstablishedPeers: 3
+TargetNumberOfKnownBigLedgerPeers: 10
+TargetNumberOfKnownPeers: 30
+TargetNumberOfRootPeers: 10
+TestAllegraHardForkAtEpoch: 0
+TestAlonzoHardForkAtEpoch: 0
+TestBabbageHardForkAtEpoch: 0
+TestConwayHardForkAtEpoch: 0
+TestMaryHardForkAtEpoch: 0
+TestShelleyHardForkAtEpoch: 0
+TraceConnectionManager: true
+TraceConnectionManagerTransitions: true
+TraceDNSResolver: true
+TraceDNSSubscription: true
+TraceDebugPeerSelection: true
+TraceForge: true
+TraceForgeStateInfo: true
+TraceHandshake: true
+TraceInboundGovernor: true
+TraceIpSubscription: true
+TraceLedgerPeers: true
+TraceLocalConnectionManager: true
+TraceLocalHandshake: true
+TraceLocalRootPeers: true
+TracePeerSelection: true
+TracePeerSelectionActions: true
+TracePublicRootPeers: true
+TraceServer: true
+TurnOnLoggingMetrics: true
+TurnOnLogging: true
+UseTraceDispatcher: true
+TraceOptionForwarder:
+  connQueueSize: 64
+  disconnQueueSize: 128
+  maxReconnectDeplay: 30
+TraceOptions:
+  '':
+    backends:
+    - EKGBackend
+    - Forwarder
+    detail: DNormal
+    severity: Notice
+  BlockFetch.Client.CompletedBlockFetch:
+    maxFrequency: 2
+  BlockFetch.Decision:
+    severity: Silence
+  ChainDB:
+    severity: Info
+  ChainDB.AddBlockEvent.AddBlockValidation:
+    severity: Silence
+  ChainDB.AddBlockEvent.AddBlockValidation.ValidCandidate:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToQueue:
+    maxFrequency: 2
+  ChainDB.AddBlockEvent.AddedBlockToVolatileDB:
+    maxFrequency: 2
+  ChainDB.CopyToImmutableDBEvent.CopiedBlockToImmutableDB:
+    maxFrequency: 2
+  ChainSync.Client:
+    severity: Warning
+  Forge.Loop:
+    severity: Info
+  Forge.StateInfo:
+    severity: Info
+  Mempool:
+    severity: Silence
+  Net.ConnectionManager.Remote:
+    severity: Info
+  Net.ConnectionManager.Remote.ConnectionManagerCounters:
+    severity: Silence
+  Net.ErrorPolicy:
+    severity: Info
+  Net.ErrorPolicy.Local:
+    severity: Info
+  Net.InboundGovernor:
+    severity: Warning
+  Net.InboundGovernor.Remote:
+    severity: Info
+  Net.Mux.Remote:
+    severity: Info
+  Net.PeerSelection:
+    severity: Silence
+  Net.PeerSelection.Actions:
+    severity: Info
+  Net.Subscription.DNS:
+    severity: Info
+  Net.Subscription.IP:
+    severity: Info
+  Resources:
+    severity: Silence
+  Startup.DiffusionInit:
+    severity: Info


### PR DESCRIPTION
Create Dingo variants for 10.4.1, 10.5.1, and adversary testnets.

- 10.4.1: Switch Dingo to use latest
- 10.5.1: Copy cardano_node_10.5.1 and add latest Dingo
- Adversary: Copy cardano_node_with_adversary and add latest Dingo w/ custom topology