### PR TITLE
feat: use blinklabs-io/haskell image for adversary

### DIFF
--- a/adversary/Dockerfile
+++ b/adversary/Dockerfile
@@ -1,102 +1,11 @@
-FROM docker.io/debian@sha256:8810492a2dd16b7f59239c1e0cc1e56c1a1a5957d11f639776bd6798e795608b AS build
+FROM ghcr.io/blinklabs-io/haskell:9.6.6-3.12.1.0-1 AS build
 
-ARG BLST_VERSION="${BLST_VERSION:-0.3.11}"
-ARG BOOTSTRAP_HASKELL_CABAL_VERSION="${BOOTSTRAP_HASKELL_CABAL_VERSION:-3.12.1.0}"
-ARG BOOTSTRAP_HASKELL_GHC_VERSION="${BOOTSTRAP_HASKELL_GHC_VERSION:-9.6.7}"
-ARG CARDANO_CLI_VERSION="${CARDANO_CLI_VERSION:-10.5.0.0}"
-ARG CARDANO_NODE_REF="${CARDANO_NODE_REF:-10.2.1}"
-ARG CARDANO_NODE_REPO="${CARDANO_NODE_REPO:-https://github.com/IntersectMBO/cardano-node.git}"
-ARG JOBS="${JOBS:-8}"
-ARG LIBSODIUM_VERSION="${LIBSODIUM_VERSION:-dbb48cc}"
-ARG SECP256K1_VERSION="${SECP256K1_VERSION:-ac83be33}"
-ARG UV_VERSION="${UV_VERSION:-0.6.11}"
+ARG JOBS=8
 
 # Set time zone
 ENV TZ="UTC"
 RUN ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && \
     echo ${TZ} > /etc/timezone
-
-# Install packages required in build stage
-RUN apt update && \
-    apt install -y --no-install-recommends \
-        autoconf \
-        automake \
-        build-essential \
-        ca-certificates \
-        curl \
-        g++ \
-        git \
-        gnupg \
-        libffi-dev \
-        libgmp-dev \
-        liblmdb-dev \
-        libncurses-dev \
-        libssl-dev \
-        libsystemd-dev \
-        libtinfo-dev \
-        libtool \
-        pkg-config \
-        tar \
-        zlib1g-dev
-
-# Install GHCup
-RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
-
-# Activate GHCup
-RUN ln -s /root/.ghcup/bin/cabal-${BOOTSTRAP_HASKELL_CABAL_VERSION} /usr/local/bin/cabal && \
-    ln -s /root/.ghcup/ghc/${BOOTSTRAP_HASKELL_GHC_VERSION}/bin/ghc-${BOOTSTRAP_HASKELL_GHC_VERSION} /usr/local/bin/ghc
-
-# Clone libsodium.git repository
-WORKDIR /usr/local/src
-RUN git clone --branch master https://github.com/IntersectMBO/libsodium.git
-
-# Build libsodium
-WORKDIR /usr/local/src/libsodium
-RUN git checkout ${LIBSODIUM_VERSION} && \
-    ./autogen.sh && \
-    ./configure && \
-    make && \
-    make check && \
-    make install -j${JOBS}
-
-# Clone secp256k1.git repository
-WORKDIR /usr/local/src
-RUN git clone --branch master https://github.com/bitcoin-core/secp256k1.git
-
-# Build secp256k1
-WORKDIR /usr/local/src/secp256k1
-RUN git checkout ${SECP256K1_VERSION} && \
-    ./autogen.sh && \
-    ./configure --prefix=/usr --enable-module-schnorrsig --enable-experimental && \
-    make && \
-    make check && \
-    make install -j${JOBS}
-
-# Clone blst.git repository
-WORKDIR /usr/local/src
-RUN git clone --branch master https://github.com/supranational/blst.git
-
-# Build blst
-WORKDIR /usr/local/src/blst
-RUN git checkout v${BLST_VERSION} && \
-    ./build.sh
-RUN echo "prefix=/usr/local\n\
-exec_prefix=/usr/local\n\
-libdir=/usr/local/lib\n\
-includedir=/usr/local/include\n\
-\n\
-Name: libblst\n\
-Description: Multilingual BLS12-381 signature library\n\
-URL: https://github.com/supranational/blst\n\
-Version: ${BLST_VERSION}\n\
-Cflags: -I/usr/local/include\n\
-Libs: -L/usr/local/lib -lblst" >/usr/local/src/blst/libblst.pc
-
-RUN mv /usr/local/src/blst/libblst.pc /usr/local/lib/pkgconfig/ && \
-    mv /usr/local/src/blst/bindings/blst.h /usr/local/include/ && \
-    mv /usr/local/src/blst/bindings/blst.hpp /usr/local/include/ && \
-    mv /usr/local/src/blst/bindings/blst_aux.h /usr/local/include/ && \
-    mv /usr/local/src/blst/libblst.a /usr/local/lib
 
 # Update path environment variables
 ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH" \
@@ -109,8 +18,8 @@ RUN --mount=type=cache,target=/root/.local/state/cabal/store \
     --mount=type=cache,target=/root/.cache/cabal \
     --mount=type=cache,target=./dist-newstyle \
     cabal update && \
-    cabal install --install-method=copy
-RUN cp /root/.cabal/bin/adversary /usr/local/bin/
+    cabal build all && \
+    cp -p dist-newstyle/build/$(uname -m)-linux/ghc-${GHC_VERSION}/adversary-0.1.0.0/x/adversary/build/adversary/adversary /usr/local/bin/
 
 #---------------------------------------------------------------------
 
@@ -131,7 +40,7 @@ RUN ln -snf /usr/local/lib/libsodium.so /usr/local/lib/libsodium.so.23 && \
 RUN ldconfig
 
 # Copy secp256k1 library
-COPY --from=build --chown=root:root /usr/local/src/secp256k1/.libs/libsecp256k1.so /usr/local/lib
+COPY --from=build --chown=root:root /usr/local/lib/libsecp256k1.so /usr/local/lib
 RUN ln -snf /usr/local/lib/libsecp256k1.so /usr/local/lib/libsecp256k1.so.1 && \
     ln -snf /usr/local/lib/libsecp256k1.so /usr/local/lib/libsecp256k1.so.1.0.1
 RUN ldconfig

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -10,9 +10,6 @@ testnet:=cardano_node_master
 url:=https://cardano.antithesis.com/api/v1/launch/cardano
 username:=cardano
 
-# Required for builds on OSX ARM
-export DOCKER_DEFAULT_PLATFORM?=linux/amd64
-
 export registry
 
 help:


### PR DESCRIPTION
Blink Labs maintains both amd64 and arm64 variants of a Haskell builder image including all of the prerequisite libraries for building on Cardano such as libsecp256kp1 and BLST. This reduces the compilation times significantly. Also, it restores ARM support for Docker Desktop users on MacOS without using emulation.

<img width="392" height="595" alt="Screenshot 2025-09-19 at 8 26 27 AM" src="https://github.com/user-attachments/assets/310b3675-8737-49f7-9f1c-255f0769d4bf" />
