### PR TITLE
fix(configurator): remove empty byron genesis ftsSeed

### DIFF
--- a/compose/configurator/configurator.sh
+++ b/compose/configurator/configurator.sh
@@ -128,6 +128,9 @@ set_start_time() {
 
     # .startTime
     jq ".startTime = ${SYSTEM_START_UNIX}" "${BYRON_GENESIS_JSON}" | write_file "${BYRON_GENESIS_JSON}"
+
+    # .ftsSeed (Dingo as of 0.17 needs this as a string, empty so removing it)
+    jq "del(.ftsSeed)" "${BYRON_GENESIS_JSON}" | write_file "${BYRON_GENESIS_JSON}"
 }
 
 


### PR DESCRIPTION
This allows Dingo 0.17.0 to run by removing the Byron genesis ftsSeed empty object. This comes from #24 and is needed for the current versions of Dingo to run.